### PR TITLE
Quit inserting fixtures when an error occurs in processing data

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "mocha": "mocha -r spec/global.js spec/util.coffee spec/master-data-resource.coffee spec/fixture.coffee spec/lib/*.coffee",
-    "single": "mocha -r spec/global.js spec/util.coffee",
+    "single": "mocha -r spec/global.js",
     "test": "gulp build && DIST=1 npm run mocha && npm run base-domainify-test && npm run uglify-js-test",
     "base-domainify-test": "cd test/base-domainify; ./test.sh; cd ../..",
     "uglify-js-test": "rm -rf test/uglify-js/build && gulp uglify-test && node test/uglify-js/build/index.js",

--- a/spec/fixture.coffee
+++ b/spec/fixture.coffee
@@ -11,6 +11,16 @@ describe 'Fixture', ->
             facade.insertFixtures(dirname: __dirname + '/fixtures/empty', debug: true)
 
 
+        it 'fails when attempting to insert invalid data', ->
+
+            facade = require('./create-facade').create('domain')
+
+            facade.insertFixtures(dirname: __dirname + '/fixtures/invalid').then =>
+                throw new Error('this should not be occurred.')
+
+            , (e) =>
+                assert e.message.match /Invalid fixture in model 'member'\./
+
         it 'inserts data', ->
             facade = require('./create-facade').create('domain')
 

--- a/spec/fixtures/invalid/data/member.coffee
+++ b/spec/fixtures/invalid/data/member.coffee
@@ -1,0 +1,2 @@
+
+module.exports = {}


### PR DESCRIPTION
We couldn't see what happens during inserting fixtures when an error occurred. This PR enables the repository to throw informative error about fixtures.