### PR TITLE
Base#deprecated(methodName, message)

### DIFF
--- a/spec/lib/base.coffee
+++ b/spec/lib/base.coffee
@@ -1,0 +1,29 @@
+
+facade = require('../create-facade').create()
+{ Base } = require '../base-domain'
+
+describe 'Base', ->
+
+    describe 'deprecated', ->
+
+        before ->
+            @consoleError = console.error
+
+        after ->
+            console.error = @consoleError
+
+
+        it 'shows message about deprecation', (done) ->
+
+            class SomeClass extends Base
+                foo: ->
+                    @deprecated('SomeClass#foo()', 'Call "bar" instead.')
+
+            instance = new SomeClass(facade)
+
+            console.error = (str) ->
+                assert str.match /Deprecated method: 'SomeClass#foo\(\)'\. Call "bar" instead\./
+                done()
+
+            instance.foo()
+

--- a/src/lib/base.coffee
+++ b/src/lib/base.coffee
@@ -151,4 +151,19 @@ class Base
         new DomainError(reason, message)
 
 
+    ###*
+    Show indication message of deprecated method
+
+    @method deprecated
+    @protected
+    @param {String} methodName
+    @param {String} message
+    @return {Error}
+    ###
+    deprecated: (methodName, message) ->
+        try
+            line = new Error().stack.split('\n')[3]
+            console.error("Deprecated method: '#{methodName}'. #{message if message}\n", line)
+        catch e
+
 module.exports = Base


### PR DESCRIPTION
example

```coffee
class Foo extends ValueObject
  method1: ->
    @deprecated('Foo#method1()', 'use method2 instead.')
```