### PR TITLE
Use console.warn instead of console.error in deprecated

### DIFF
--- a/spec/lib/base.coffee
+++ b/spec/lib/base.coffee
@@ -7,10 +7,10 @@ describe 'Base', ->
     describe 'deprecated', ->
 
         before ->
-            @consoleError = console.error
+            @consoleWarn = console.warn
 
         after ->
-            console.error = @consoleError
+            console.error = @consoleWarn
 
 
         it 'shows message about deprecation', (done) ->
@@ -21,7 +21,7 @@ describe 'Base', ->
 
             instance = new SomeClass(facade)
 
-            console.error = (str) ->
+            console.warn = (str) ->
                 assert str.match /Deprecated method: 'SomeClass#foo\(\)'\. Call "bar" instead\./
                 done()
 

--- a/src/lib/base.coffee
+++ b/src/lib/base.coffee
@@ -167,7 +167,7 @@ class Base
     deprecated: (methodName, message) ->
         try
             line = new Error().stack.split('\n')[3]
-            console.error("Deprecated method: '#{methodName}'. #{message if message}\n", line)
+            console.warn("Deprecated method: '#{methodName}'. #{message if message}\n", line)
         catch e
 
 module.exports = Base


### PR DESCRIPTION
`console.warn` should be used than `console.error` on the deprecation loggings. 