### PR TITLE
avoid unnecessary dynamic require

### DIFF
--- a/src/lib/facade.coffee
+++ b/src/lib/facade.coffee
@@ -401,7 +401,7 @@ class Facade
             @nonExistingClassNames[modFullName] = true
 
             modFullName = fullName # strip module name
-            klass = @getModule().requireOwn(fullName)
+            klass = @classes[fullName] or @getModule().requireOwn(fullName)
 
         if not klass?
             @nonExistingClassNames[fullName] = true


### PR DESCRIPTION
Avoid dynamic require if the module was already loaded. 