### PR TITLE
convert Date to ISOString when it has toISOString method on serializing

### DIFF
--- a/spec/util.coffee
+++ b/spec/util.coffee
@@ -196,6 +196,22 @@ describe 'Util', ->
 
             assert Util.serialize(diary1) is JSON.stringify { id: 'abc', p1: 123, p2: 'str', d: { id: 'def', p1: 123, p2: 'str' }, __className__: 'diary' }
 
+        it 'converts value to ISOString when it has toISOString method', ->
+            class Diary extends Entity
+            facade.addClass('diary', Diary)
+            today = new Date()
+            todayStr = today.toISOString()
+            diary1 = facade.createModel('diary', { id: 'abc', date: today, p1: 123, p2: 'str' })
+            diary2 = facade.createModel('diary', { id: 'def', date: today, p1: 123, p2: 'str' })
+            diary1.d = diary2
+
+            expectedObject = { id: 'abc', date: todayStr, p1: 123, p2: 'str', d: { id: 'def', date: todayStr, p1: 123, p2: 'str' }, __className__: 'diary' }
+
+            expectedStr = JSON.stringify expectedObject
+            console.log(diary1)
+
+            assert Util.serialize(diary1) is expectedStr
+
 
     describe 'deserialize', ->
 

--- a/src/util.coffee
+++ b/src/util.coffee
@@ -60,11 +60,24 @@ class Util
         cameled.replace(/([A-Z])/g, (st)-> '-' + st.charAt(0).toLowerCase()).slice(1)
 
 
+    ###*
+    converts instans with toISOString method to ISOString
+
+    @method modifyDate
+    @static
+    @param {Entity|Object}
+    @return {String} ISOString
+    ###
+    @modifyDate: (data) ->
+
     @serialize: (v) ->
 
         JSON.stringify do attachClassName = (val = v, inModel = false) ->
 
             return val if not val? or typeof val isnt 'object'
+
+            if val.toISOString
+                return val.toISOString()
 
             if Array.isArray val
                 return (attachClassName(item, inModel) for item in val)


### PR DESCRIPTION
Because serializing date instance and deserializing it becomes an object,
convert value to ISOString when it has toISOString method on serializing.